### PR TITLE
fix: cypress vite dev server can't run

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,9 +1517,9 @@
     uuid "^8.3.2"
 
 "@cypress/vite-dev-server@^2.2.2":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@cypress/vite-dev-server/-/vite-dev-server-2.2.3.tgz#7b21031f94d92b338860ead3a8c73f23c96c4e1d"
-  integrity sha512-E9cPKwReweYGRsupfR6Va1R1bHv3zPb3gHG68fyQwAjG4oPORaQlgfFWiR2i1pF+tRftvNfM0O2PBuKX3IvPxg==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@cypress/vite-dev-server/-/vite-dev-server-2.2.2.tgz#dd16b7470ddd1ff095678b61c56da52ac02f44ed"
+  integrity sha512-02y/Fm0N+CQjKbSjjRtktPgPbp91kOvtc8+WW2l2odIYQkKlG6IOCpmgc898muW0lBAcCszdEIHR/ItdZDiYPw==
   dependencies:
     debug "^4.3.2"
     get-port "^5.1.1"


### PR DESCRIPTION
## 📝 Description

update @cypress/vite-dev-server to 2.2.2,beacse of it has bug to make e2e test can't run

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

lol