### PR TITLE
fix error link in issue template config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/illa-family/discussions
+    url: https://github.com/orgs/illa-family/discussions
     about: Ask questions and discuss topics with other community members
   - name: Chat with other community members
     url: https://discord.gg/2tGBuJkgd6


### PR DESCRIPTION
update https://github.com/illa-family/discussions to https://github.com/orgs/illa-family/discussions

## 📝 Description

Add a brief description.

## 💣 Is this a breaking change (Yes/No):

- [x] Yes
- [ ] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

fix issue template error