### PR TITLE
fix(eslint error): unable to resolve path to module 'vite' in vite.config.ts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,9 @@ module.exports = {
       version: "detect",
     },
     "import/resolver": {
+      node: {
+        extensions: ['.ts', '.tsx']
+      },
       typescript: {
         project: "apps/*/tsconfig.json",
       },


### PR DESCRIPTION
## 📝 Description

When I cloned the project to the local and execute the yarn command in the root directory (install the npm package), then open the apps/builder/vite.conifg.ts file, it shows unable to resolve path to module 'vite' in vite.config. ts.

When I found out that this was an error from eslint, I modified the eslintrc file in the root directory and fixed it.

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

![image](https://user-images.githubusercontent.com/26076975/196628593-072cec21-5257-443d-8aea-ba900df5432c.png)

