### PR TITLE
Fix typeof check for value in regex validation

### DIFF
--- a/apps/builder/src/widgetLibrary/PublicSector/InvalidMessage/utils.tsx
+++ b/apps/builder/src/widgetLibrary/PublicSector/InvalidMessage/utils.tsx
@@ -123,7 +123,7 @@ export const handleCheckPattern = (
       break
     }
     case "Regex":
-      if (!reg || typeof value === undefined) return
+      if (!reg || typeof value === "undefined") return
       try {
         let finalReg = reg
         if (reg.startsWith("/") && reg.endsWith("/")) {


### PR DESCRIPTION
## 📝 Description

The `typeof something === undefined` is always `false` since `typeof` operator returns a string, so we should compare with a `"undefined"` string as in other cases.

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.
